### PR TITLE
Fixed `j-Approve`

### DIFF
--- a/j-Approve/component.js
+++ b/j-Approve/component.js
@@ -57,6 +57,8 @@ COMPONENT('approve', 'cancel:Cancel', function(self, config, cls) {
 
 	self.show = function(message, a, b, fn) {
 
+		clearTimeout2(self.id);
+
 		if (typeof(b) === 'function') {
 			fn = b;
 			b = config.cancel;


### PR DESCRIPTION
Two consequent calls to approve/show caused the second one to automatically hide after 1 second since the first one set a timeout.